### PR TITLE
Hotfix: lolnews filepath

### DIFF
--- a/handlers/lolnews.py
+++ b/handlers/lolnews.py
@@ -67,7 +67,7 @@ def handle(event={}, context={}):
     collector = LOLeSportsCollector()
 
     filename = 'lolnews.xml'
-    filepath = '' + filename
+    filepath = '/tmp/' + filename
     selflink = RssFeedGenerator.selflink_s3(filename)
 
     generator = RssFeedGenerator(


### PR DESCRIPTION
- Исправлен путь для генерируемого файла 'lolnews'.